### PR TITLE
Fix GRADE_PATTERN minor bug & Change argument data structure

### DIFF
--- a/src/main/java/seedu/duke/parser/CommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/CommandMetadata.java
@@ -1,0 +1,47 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CommandMetadata {
+    private final Pattern pattern;
+    private final String[] groupArguments;
+    private final Function<Map<String, String>, Command> constructor;
+
+    CommandMetadata(
+            Pattern pattern,
+            String[] groupArguments,
+            Function<Map<String, String>, Command> constructor
+    ) {
+        this.pattern = pattern;
+        this.groupArguments = groupArguments;
+        this.constructor = constructor;
+    }
+
+    Pattern getPattern() {
+        return pattern;
+    }
+
+    String[] getGroupArguments() {
+        return groupArguments;
+    }
+
+    Function<Map<String, String>, Command> getConstructor() {
+        return constructor;
+    }
+
+    Map<String, String> getCommandArguments(Matcher matcher) {
+        Map<String, String> arguments = new HashMap<>();
+
+        for (int i = 0; i < groupArguments.length; i++) {
+            arguments.put(groupArguments[i], matcher.group(groupArguments[i]));
+        }
+
+        return arguments;
+    }
+}

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -1,30 +1,21 @@
 package seedu.duke.parser;
 
 import java.util.function.Function;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.duke.command.Command;
-// import seedu.duke.command.AddCommand;
+import seedu.duke.command.AddCommand;
 // import seedu.duke.command.ListCommand;
 // import seedu.duke.command.RemoveCommand;
 
 public class Parser {
 
-    enum CommandType {
-        INIT,
-        GPA,
-        VIEW,
-        REMOVE_MODULE,
-        ADD_MODULE,
-        GRADE,
-        INVALID
-    }
-
+    // String Pattern inputs
     private static final Pattern INIT_PATTERN =
-            Pattern.compile("init", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("init\\s+n/(?<name>[A-Za-z0-9 ]+)", Pattern.CASE_INSENSITIVE);
     private static final Pattern GPA_PATTERN =
             Pattern.compile("gpa", Pattern.CASE_INSENSITIVE);
     private static final Pattern VIEW_PATTERN =
@@ -38,75 +29,80 @@ public class Parser {
             Pattern.compile("grade\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)" +
                     "\\s+g/(?<grade>[ab][+-]?|[cd][+]?|f|[1-5](?:\\.0|\\.5)?|0\\.0?)", Pattern.CASE_INSENSITIVE);
 
-    private static Map<CommandType, Pattern> commandPatternMap = initCommandPatternMap();
-    private static Map<CommandType, String[]> commandGroupArgumentMap = initCommandGroupArgumentMap();
-    private static Map<CommandType, Function<Map<String, String>, Command>> commandClassMap = initCommandClassMap();
+    // Argument Group captures
+    private static final String[] INIT_ARGUMENTS = {"name"};
+    private static final String[] GPA_ARGUMENTS = {};
+    private static final String[] VIEW_ARGUMENTS = {"mode"};
+    private static final String[] REMOVE_MODULE_ARGUMENTS = {"courseCode"};
+    private static final String[] ADD_MODULE_ARGUMENTS = {"courseCode", "status", "semester", "mc"};
+    private static final String[] GRADE_ARGUMENTS = {"courseCode", "grade"};
 
-    private static Map<CommandType, Pattern> initCommandPatternMap() {
-        Map<CommandType, Pattern> commandPatternMap = new HashMap<>();
+    // Command constructor function
+    private static final Function<Map<String, String>, Command> INIT_CONSTRUCTOR = Parser::initCommand;
+    private static final Function<Map<String, String>, Command> GPA_CONSTRUCTOR = Parser::gpaCommand;
+    private static final Function<Map<String, String>, Command> VIEW_CONSTRUCTOR = Parser::listCommand;
+    private static final Function<Map<String, String>, Command> REMOVE_MODULE_CONSTRUCTOR = Parser::removeCommand;
+    private static final Function<Map<String, String>, Command> ADD_MODULE_CONSTRUCTOR = Parser::addCommand;
+    private static final Function<Map<String, String>, Command> GRADE_CONSTRUCTOR = Parser::gradeCommand;
 
-        commandPatternMap.put(CommandType.INIT, INIT_PATTERN);
-        commandPatternMap.put(CommandType.GPA, GPA_PATTERN);
-        commandPatternMap.put(CommandType.GRADE, GRADE_PATTERN);
-        commandPatternMap.put(CommandType.VIEW, VIEW_PATTERN);
-        commandPatternMap.put(CommandType.REMOVE_MODULE, REMOVE_MODULE_PATTERN);
-        commandPatternMap.put(CommandType.ADD_MODULE, ADD_MODULE_PATTERN);
+    // Initialise ArrayList that puts all the commandMetadata together
+    private static final ArrayList<CommandMetadata> metadataList = initMetadataList();
 
-        return commandPatternMap;
-    }
+    private static ArrayList<CommandMetadata> initMetadataList() {
+        ArrayList<CommandMetadata> list = new ArrayList<>();
 
-    private static Map<CommandType, String[]> initCommandGroupArgumentMap() {
-        Map<CommandType, String[]> commandGroupArgumentMap = new HashMap<>();
+        list.add(new CommandMetadata(INIT_PATTERN, INIT_ARGUMENTS, INIT_CONSTRUCTOR));
+        list.add(new CommandMetadata(GPA_PATTERN, GPA_ARGUMENTS, GPA_CONSTRUCTOR));
+        list.add(new CommandMetadata(VIEW_PATTERN, VIEW_ARGUMENTS, VIEW_CONSTRUCTOR));
+        list.add(new CommandMetadata(REMOVE_MODULE_PATTERN, REMOVE_MODULE_ARGUMENTS, REMOVE_MODULE_CONSTRUCTOR));
+        list.add(new CommandMetadata(ADD_MODULE_PATTERN, ADD_MODULE_ARGUMENTS, ADD_MODULE_CONSTRUCTOR));
+        list.add(new CommandMetadata(GRADE_PATTERN, GRADE_ARGUMENTS, GRADE_CONSTRUCTOR));
 
-        commandGroupArgumentMap.put(CommandType.INIT, new String[]{});
-        commandGroupArgumentMap.put(CommandType.GPA, new String[]{});
-        commandGroupArgumentMap.put(CommandType.GRADE, new String[]{"courseCode", "grade"});
-        commandGroupArgumentMap.put(CommandType.VIEW, new String[]{"mode"});
-        commandGroupArgumentMap.put(CommandType.REMOVE_MODULE, new String[]{"courseCode"});
-        commandGroupArgumentMap.put(CommandType.ADD_MODULE, new String[]{"courseCode", "status", "semester", "mc"});
-
-        return commandGroupArgumentMap;
-    }
-
-    private static Map<CommandType, Function<Map<String, String>, Command>> initCommandClassMap() {
-        Map<CommandType, Function<Map<String, String>, Command>> commandClassMap = new HashMap<>();
-
-        // CURRENTLY UNAVAILABLE: Command Classes to execute
-        // commandClassMap.put(CommandType.INIT, args -> new InitCommand());
-        // commandClassMap.put(CommandType.GPA, args -> new GPACommand());
-        // commandClassMap.put(CommandType.GRADE, args -> new GradeCommand(args));
-        // commandClassMap.put(CommandType.ADD_MODULE, args -> new AddCommand(args));
-        // commandClassMap.put(CommandType.VIEW, args -> new ListCommand(args));
-        // commandClassMap.put(CommandType.REMOVE_MODULE, args -> new RemoveCommand(args));
-
-        return commandClassMap;
+        return list;
     }
 
     public static void getCommand(String userInput) {
-        for (Map.Entry<CommandType, Pattern> entry : commandPatternMap.entrySet()) {
-            Pattern commandPattern = entry.getValue();
+        for (CommandMetadata commandMetadata : metadataList) {
+            Pattern commandPattern = commandMetadata.getPattern();
             Matcher matcher = commandPattern.matcher(userInput);
 
             if (matcher.matches()) {
-                CommandType commandType = entry.getKey();
-                // Function<Map<String, String>, Command> commandCreator = commandClassMap.get(commandType);
-                Map<String, String> arguments = getCommandArguments(commandType, matcher);
-
-                // return commandCreator.apply(arguments);
+                Map<String, String> commandArguments = commandMetadata.getCommandArguments(matcher);
+                Function<Map<String, String>, Command> commandClassConstructor = commandMetadata.getConstructor();
                 return;
             }
         }
         return;
     }
 
-    private static Map<String, String> getCommandArguments(CommandType command, Matcher matcher) {
-        String[] groupNames = commandGroupArgumentMap.get(command);
-        Map<String, String> arguments = new HashMap<>();
+    // Class Constructor functions
+    private static Command initCommand(Map<String, String> args) {
+        // return new InitCommand(args);
+        return new AddCommand();
+    }
 
-        for (int i = 0; i < groupNames.length; i++) {
-            arguments.put(groupNames[i], matcher.group(groupNames[i]));
-        }
+    private static Command gpaCommand(Map<String, String> args) {
+        // return new GPACommand();
+        return new AddCommand();
+    }
 
-        return arguments;
+    private static Command listCommand(Map<String, String> args) {
+        // return new ListCommand();
+        return new AddCommand();
+    }
+
+    private static Command removeCommand(Map<String, String> args) {
+        // return new RemoveCommand(args);
+        return new AddCommand();
+    }
+
+    private static Command addCommand(Map<String, String> args) {
+        // return new AddCommand(args);
+        return new AddCommand();
+    }
+
+    private static Command gradeCommand(Map<String, String> args) {
+        // return new GradeCommand();
+        return new AddCommand();
     }
 }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -36,11 +36,11 @@ public class Parser {
                     "\\s+w/(?<semester>[1-9]|10)\\s+m/(?<mc>[1-9]|1[0-2])", Pattern.CASE_INSENSITIVE);
     private static final Pattern GRADE_PATTERN =
             Pattern.compile("grade\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)" +
-                    "\\s+g/(?<grade>[ab]?[+-]?|[cd][+]?|f|[1-5](?:\\.0|\\.5)?|0\\.0?)", Pattern.CASE_INSENSITIVE);
+                    "\\s+g/(?<grade>[ab][+-]?|[cd][+]?|f|[1-5](?:\\.0|\\.5)?|0\\.0?)", Pattern.CASE_INSENSITIVE);
 
     private static Map<CommandType, Pattern> commandPatternMap = initCommandPatternMap();
     private static Map<CommandType, String[]> commandGroupArgumentMap = initCommandGroupArgumentMap();
-    private static Map<CommandType, Function<String[], Command>> commandClassMap = initCommandClassMap();
+    private static Map<CommandType, Function<Map<String, String>, Command>> commandClassMap = initCommandClassMap();
 
     private static Map<CommandType, Pattern> initCommandPatternMap() {
         Map<CommandType, Pattern> commandPatternMap = new HashMap<>();
@@ -68,8 +68,8 @@ public class Parser {
         return commandGroupArgumentMap;
     }
 
-    private static Map<CommandType, Function<String[], Command>> initCommandClassMap() {
-        Map<CommandType, Function<String[], Command>> commandClassMap = new HashMap<>();
+    private static Map<CommandType, Function<Map<String, String>, Command>> initCommandClassMap() {
+        Map<CommandType, Function<Map<String, String>, Command>> commandClassMap = new HashMap<>();
 
         // CURRENTLY UNAVAILABLE: Command Classes to execute
         // commandClassMap.put(CommandType.INIT, args -> new InitCommand());
@@ -89,8 +89,8 @@ public class Parser {
 
             if (matcher.matches()) {
                 CommandType commandType = entry.getKey();
-                // Function<String[], Command> commandCreator = commandClassMap.get(commandType);
-                String[] arguments = getCommandArguments(commandType, matcher);
+                // Function<Map<String, String>, Command> commandCreator = commandClassMap.get(commandType);
+                Map<String, String> arguments = getCommandArguments(commandType, matcher);
 
                 // return commandCreator.apply(arguments);
                 return;
@@ -99,12 +99,12 @@ public class Parser {
         return;
     }
 
-    private static String[] getCommandArguments(CommandType command, Matcher matcher) {
+    private static Map<String, String> getCommandArguments(CommandType command, Matcher matcher) {
         String[] groupNames = commandGroupArgumentMap.get(command);
-        String[] arguments = new String[groupNames.length];
+        Map<String, String> arguments = new HashMap<>();
 
         for (int i = 0; i < groupNames.length; i++) {
-            arguments[i] = matcher.group(groupNames[i]);
+            arguments.put(groupNames[i], matcher.group(groupNames[i]));
         }
 
         return arguments;

--- a/src/test/java/seedu/duke/FAPTest.java
+++ b/src/test/java/seedu/duke/FAPTest.java
@@ -6,5 +6,7 @@ import org.junit.jupiter.api.Test;
 
 class FAPTest {
     @Test
-    public void mainTest() { assertTrue(true);}
+    public void mainTest() {
+        assertTrue(true);
+    }
 }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -1,10 +1,9 @@
 package seedu.duke.parser;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 
-public class parserTest {
+public class ParserTest {
     @Test
     public void parserTestSample() {
         assertTrue(true);


### PR DESCRIPTION
1. Fix -> GRADE_PATTERN allowing [+-] grade without an alphabet. 
2. Change parser command arguments to use map<string,string> type instead of arrays to reduce chances of using magic literals.