### PR TITLE
Fix init name argument to be case sensitive

### DIFF
--- a/src/main/java/seedu/duke/parser/CommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/CommandMetadata.java
@@ -38,8 +38,12 @@ public class CommandMetadata {
     Map<String, String> getCommandArguments(Matcher matcher) {
         Map<String, String> arguments = new HashMap<>();
 
-        for (int i = 0; i < groupArguments.length; i++) {
-            arguments.put(groupArguments[i], matcher.group(groupArguments[i]).toUpperCase());
+        for (String groupArgument : groupArguments) {
+            String argument = matcher.group(groupArgument);
+            if (groupArgument.equals("courseCode") || groupArgument.equals("grade")) {
+                argument = argument.toUpperCase();
+            }
+            arguments.put(groupArgument, argument);
         }
 
         return arguments;

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -1,6 +1,6 @@
 __________________________________________________
 Hello! This is your CEG Future Academic Planner!
 What can I do for you?
-Hello JAMES GOSLING!
+Hello James Gosling!
 What would you like to do today?
 Bye. Enjoy your studies!


### PR DESCRIPTION
## Overview
Fixes the `init` command's name argument, ensuring it is displayed in proper case.

## Changes
- **Modified `CommandMetadata.java`:**
  - Introduced a conditional check within the loop to uppercase the argument value only if the group argument is "courseCode" or "grade".