### PR TITLE
Refactor Parser Code into separate classes

### DIFF
--- a/src/main/java/seedu/duke/FAP.java
+++ b/src/main/java/seedu/duke/FAP.java
@@ -20,6 +20,7 @@ public class FAP {
     public static JsonManager jsonManager = new JsonManager();
 
     public static void main(String[] args) {
+        LOGGER.setLevel(Level.OFF);
         try {
             printGreeting();
             assert moduleList != null : "moduleList should not be null";

--- a/src/main/java/seedu/duke/command/InvalidCommand.java
+++ b/src/main/java/seedu/duke/command/InvalidCommand.java
@@ -1,8 +1,23 @@
 package seedu.duke.command;
 
+import seedu.duke.ui.Ui;
+
 public class InvalidCommand extends Command {
+
+    private final String errorMessage;
+
+    public InvalidCommand() {
+        this.errorMessage = "Invalid Command";
+    }
+
+    public InvalidCommand(String errorMessage) {
+        this.errorMessage = errorMessage != null ? errorMessage : "Invalid Command";
+    }
+
     @Override
     public void execute(String userInput) {
-        System.out.println("INVALID COMMAND");
+        if (!errorMessage.isEmpty()) {
+            Ui.printMessage(errorMessage);
+        }
     }
 }

--- a/src/main/java/seedu/duke/exceptions/ParserException.java
+++ b/src/main/java/seedu/duke/exceptions/ParserException.java
@@ -1,0 +1,7 @@
+package seedu.duke.exceptions;
+
+public class ParserException extends Exception {
+    public ParserException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/seedu/duke/parser/AddCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/AddCommandMetadata.java
@@ -1,0 +1,38 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+import seedu.duke.command.AddCommand;
+import seedu.duke.command.InvalidCommand;
+import seedu.duke.exceptions.ModuleNotFoundException;
+
+import java.util.Map;
+import java.util.logging.Level;
+
+import static seedu.duke.FAP.LOGGER;
+
+public class AddCommandMetadata extends CommandMetadata {
+    private static final String ADD_KEYWORD = "add";
+    private static final String ADD_PATTERN_REGEX =
+            "add\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)\\s+w/(?<semester>[1-8])";
+    private static final String[] ADD_ARGUMENTS = {"courseCode", "semester"};
+
+    public AddCommandMetadata() {
+        super(ADD_KEYWORD, ADD_PATTERN_REGEX, ADD_ARGUMENTS);
+    }
+
+    // Add Command Creator
+    @Override
+    protected Command createCommandInstance(Map<String, String> args) {
+        try {
+            String moduleCode = args.getOrDefault("courseCode", "COURSECODE_ERROR");
+            String semester = args.getOrDefault("semester", "SEMESTER_ERROR");
+            int semesterInt = Integer.parseInt(semester);
+
+            return new AddCommand(moduleCode, semesterInt);
+        } catch (ModuleNotFoundException e) {
+            LOGGER.log(Level.SEVERE, "An error occurred: " + e.getMessage());
+            System.out.println("An error occurred: " + e.getMessage());
+        }
+        return new InvalidCommand();
+    }
+}

--- a/src/main/java/seedu/duke/parser/AddCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/AddCommandMetadata.java
@@ -12,12 +12,10 @@ import static seedu.duke.FAP.LOGGER;
 
 public class AddCommandMetadata extends CommandMetadata {
     private static final String ADD_KEYWORD = "add";
-    private static final String ADD_PATTERN_REGEX =
-            "add\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)\\s+w/(?<semester>[1-8])";
     private static final String[] ADD_ARGUMENTS = {"courseCode", "semester"};
 
     public AddCommandMetadata() {
-        super(ADD_KEYWORD, ADD_PATTERN_REGEX, ADD_ARGUMENTS);
+        super(ADD_KEYWORD, ADD_ARGUMENTS);
     }
 
     // Add Command Creator

--- a/src/main/java/seedu/duke/parser/ByeCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/ByeCommandMetadata.java
@@ -7,11 +7,10 @@ import java.util.Map;
 
 public class ByeCommandMetadata extends CommandMetadata {
     private static final String BYE_KEYWORD = "bye";
-    private static final String BYE_PATTERN_REGEX = "bye";
     private static final String[] BYE_ARGUMENTS = {};
 
     public ByeCommandMetadata() {
-        super(BYE_KEYWORD, BYE_PATTERN_REGEX, BYE_ARGUMENTS);
+        super(BYE_KEYWORD, BYE_ARGUMENTS);
     }
 
     // Bye Command Creator

--- a/src/main/java/seedu/duke/parser/ByeCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/ByeCommandMetadata.java
@@ -1,0 +1,22 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+import seedu.duke.command.ByeCommand;
+
+import java.util.Map;
+
+public class ByeCommandMetadata extends CommandMetadata {
+    private static final String BYE_KEYWORD = "bye";
+    private static final String BYE_PATTERN_REGEX = "bye";
+    private static final String[] BYE_ARGUMENTS = {};
+
+    public ByeCommandMetadata() {
+        super(BYE_KEYWORD, BYE_PATTERN_REGEX, BYE_ARGUMENTS);
+    }
+
+    // Bye Command Creator
+    @Override
+    protected Command createCommandInstance(Map<String, String> args) {
+        return new ByeCommand();
+    }
+}

--- a/src/main/java/seedu/duke/parser/CommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/CommandMetadata.java
@@ -1,45 +1,91 @@
 package seedu.duke.parser;
 
 import seedu.duke.command.Command;
+import seedu.duke.exceptions.ParserException;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CommandMetadata {
-    private final Pattern pattern;
-    private final String[] groupArguments;
-    private final Function<Map<String, String>, Command> constructor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-    CommandMetadata(
-            Pattern pattern,
-            String[] groupArguments,
-            Function<Map<String, String>, Command> constructor
-    ) {
-        this.pattern = pattern;
-        this.groupArguments = groupArguments;
-        this.constructor = constructor;
+public abstract class CommandMetadata {
+
+    private static Logger logger = Logger.getLogger("CommandMetadata");
+    private static Map<String, String> argRegexMap = new HashMap<>();
+    static {
+        logger.setLevel(Level.OFF);
+
+        argRegexMap.put("name", "n/(?<name>[A-Za-z0-9 ]+)");
+        argRegexMap.put("courseCode", "c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)");
+        argRegexMap.put("semester", "w/(?<semester>[1-8])");
+        argRegexMap.put("mc", "m/(?<mc>[1-9]|1[0-2])");
+        argRegexMap.put("grade", "g/(?<grade>[ab][+-]?|[cd][+]?|f|cs|cu)");
     }
 
-    Pattern getPattern() {
+    private String keyword;
+    private String regex;
+    private String[] groupArguments;
+    private int regexLength;
+    private Pattern pattern;
+
+    protected CommandMetadata(String keyword, String regex, String[] groupArguments) {
+        if (keyword == null || regex == null || groupArguments == null) {
+            throw new IllegalArgumentException("Keyword, regex, and group arguments cannot be null");
+        }
+        this.keyword = keyword;
+        this.regex = regex;
+        this.groupArguments = groupArguments;
+
+        this.regexLength = groupArguments.length + 1; // Keyword + number of Arguments
+        this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+    }
+
+    protected String getKeyword() {
+        return keyword;
+    }
+
+    protected String getRegex() {
+        return regex;
+    }
+
+    protected Pattern getPattern() {
         return pattern;
     }
 
-    String[] getGroupArguments() {
+    protected String[] getGroupArguments() {
         return groupArguments;
     }
 
-    Function<Map<String, String>, Command> getConstructor() {
-        return constructor;
+    protected Map<String, String> getArgRegexMap() {
+        return argRegexMap;
     }
 
-    Map<String, String> getCommandArguments(Matcher matcher) {
+    protected boolean matchesKeyword(String userInput) {
+        if (userInput == null || userInput.isEmpty()) {
+            return false;
+        }
+
+        userInput = userInput.trim();
+        String[] userInputParts = userInput.split("\\s+");
+        if (userInputParts[0].equalsIgnoreCase(keyword)) {
+            return true;
+        }
+        return false;
+    }
+
+    protected Map<String, String> getCommandArguments(Matcher matcher) {
         Map<String, String> arguments = new HashMap<>();
 
+        assert groupArguments != null : "groupArgument should be initialised at this point";
         for (String groupArgument : groupArguments) {
             String argument = matcher.group(groupArgument);
+            if (argument == null) {
+                continue;
+            }
+
             if (groupArgument.equals("courseCode") || groupArgument.equals("grade")) {
                 argument = argument.toUpperCase();
             }
@@ -48,4 +94,40 @@ public class CommandMetadata {
 
         return arguments;
     }
+
+    private void validateUserArguments(String argument, String argumentName) throws ParserException {
+        String argRegex = argRegexMap.get(argumentName);
+        assert argRegex != null : "Regex pattern for " + argumentName + " should already be placed in argRegexMap";
+
+        Pattern pattern = Pattern.compile(argRegex);
+        Matcher matcher = pattern.matcher(argument);
+
+        if (!matcher.matches()) {
+            logger.log(Level.INFO, "Regex pattern: " + argRegex);
+            logger.log(Level.INFO, "UserInput Argument: " + argument);
+            throw new ParserException(keyword + " command: Error in " + argumentName);
+        }
+    }
+
+    protected void validateUserInput(String userInput) throws IllegalArgumentException, ParserException {
+        assert userInput != null : "userInput should not be null at this point";
+
+        String[] userInputParts = userInput.split("\\s+");
+        assert userInputParts[0].equalsIgnoreCase(keyword) : "userInput should match keyword at this point";
+
+        if (userInputParts.length != regexLength) {
+            throw new ParserException(keyword + " command: Invalid argument length");
+        }
+
+        // Check user arguments
+        if (groupArguments.length != userInputParts.length - 1) {
+            throw new IllegalArgumentException("Regex length should be keyword + number of arguments");
+        }
+        for (int i = 0; i < groupArguments.length; i++) {
+            validateUserArguments(userInputParts[i+1], groupArguments[i]);
+        }
+        return;
+    }
+
+    protected abstract Command createCommandInstance(Map<String, String> args);
 }

--- a/src/main/java/seedu/duke/parser/CommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/CommandMetadata.java
@@ -26,19 +26,19 @@ public abstract class CommandMetadata {
     }
 
     private String keyword;
-    private String regex;
     private String[] groupArguments;
+    private String regex;
     private int regexLength;
     private Pattern pattern;
 
-    protected CommandMetadata(String keyword, String regex, String[] groupArguments) {
-        if (keyword == null || regex == null || groupArguments == null) {
+    protected CommandMetadata(String keyword, String[] groupArguments) throws IllegalArgumentException {
+        if (keyword == null || groupArguments == null) {
             throw new IllegalArgumentException("Keyword, regex, and group arguments cannot be null");
         }
         this.keyword = keyword;
-        this.regex = regex;
         this.groupArguments = groupArguments;
 
+        this.regex = generateRegex(keyword, groupArguments);
         this.regexLength = groupArguments.length + 1; // Keyword + number of Arguments
         this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
     }
@@ -61,6 +61,27 @@ public abstract class CommandMetadata {
 
     protected Map<String, String> getArgRegexMap() {
         return argRegexMap;
+    }
+
+    private static String generateRegex(String keyword, String[] groupArguments) {
+        if (keyword == null || groupArguments == null) {
+            throw new IllegalArgumentException("Keyword and groupArguments must not be null");
+        }
+
+        StringBuilder regexPattern = new StringBuilder(keyword);
+        for (String groupArgName : groupArguments) {
+            appendRegex(regexPattern, groupArgName);
+        }
+        return regexPattern.toString();
+    }
+
+    // Helper function for generateRegex
+    private static void appendRegex(StringBuilder regexPattern, String groupArgName) {
+        String argRegex = argRegexMap.get(groupArgName);
+        if (argRegex == null) {
+            throw new IllegalArgumentException("No regex pattern found for argument: " + groupArgName);
+        }
+        regexPattern.append("\\s+").append(argRegex);
     }
 
     protected boolean matchesKeyword(String userInput) {

--- a/src/main/java/seedu/duke/parser/GpaCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/GpaCommandMetadata.java
@@ -1,0 +1,22 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+import seedu.duke.command.ViewGpaCommand;
+
+import java.util.Map;
+
+public class GpaCommandMetadata extends CommandMetadata {
+    private static final String GPA_KEYWORD = "gpa";
+    private static final String GPA_PATTERN_REGEX = "gpa";
+    private static final String[] GPA_ARGUMENTS = {};
+
+    public GpaCommandMetadata() {
+        super(GPA_KEYWORD, GPA_PATTERN_REGEX, GPA_ARGUMENTS);
+    }
+
+    // Gpa Command Creator
+    @Override
+    protected Command createCommandInstance(Map<String, String> args) {
+        return new ViewGpaCommand();
+    }
+}

--- a/src/main/java/seedu/duke/parser/GpaCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/GpaCommandMetadata.java
@@ -7,11 +7,10 @@ import java.util.Map;
 
 public class GpaCommandMetadata extends CommandMetadata {
     private static final String GPA_KEYWORD = "gpa";
-    private static final String GPA_PATTERN_REGEX = "gpa";
     private static final String[] GPA_ARGUMENTS = {};
 
     public GpaCommandMetadata() {
-        super(GPA_KEYWORD, GPA_PATTERN_REGEX, GPA_ARGUMENTS);
+        super(GPA_KEYWORD, GPA_ARGUMENTS);
     }
 
     // Gpa Command Creator

--- a/src/main/java/seedu/duke/parser/GradeCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/GradeCommandMetadata.java
@@ -1,0 +1,26 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+import seedu.duke.command.GradeCommand;
+
+import java.util.Map;
+
+public class GradeCommandMetadata extends CommandMetadata {
+    private static final String GRADE_KEYWORD = "grade";
+    private static final String GRADE_PATTERN_REGEX =
+            "grade\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)\\s+g/(?<grade>[ab][+-]?|[cd][+]?|f|cs|cu)";
+    private static final String[] GRADE_ARGUMENTS = {"courseCode", "grade"};
+
+    public GradeCommandMetadata() {
+        super(GRADE_KEYWORD, GRADE_PATTERN_REGEX, GRADE_ARGUMENTS);
+    }
+
+    // Grade Command Creator
+    @Override
+    protected Command createCommandInstance(Map<String, String> args) {
+        String moduleCode = args.getOrDefault("courseCode", "COURSECODE_ERROR");
+        String grade = args.getOrDefault("grade", "GRADE_ERROR");
+
+        return new GradeCommand(moduleCode, grade);
+    }
+}

--- a/src/main/java/seedu/duke/parser/GradeCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/GradeCommandMetadata.java
@@ -7,12 +7,10 @@ import java.util.Map;
 
 public class GradeCommandMetadata extends CommandMetadata {
     private static final String GRADE_KEYWORD = "grade";
-    private static final String GRADE_PATTERN_REGEX =
-            "grade\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)\\s+g/(?<grade>[ab][+-]?|[cd][+]?|f|cs|cu)";
     private static final String[] GRADE_ARGUMENTS = {"courseCode", "grade"};
 
     public GradeCommandMetadata() {
-        super(GRADE_KEYWORD, GRADE_PATTERN_REGEX, GRADE_ARGUMENTS);
+        super(GRADE_KEYWORD, GRADE_ARGUMENTS);
     }
 
     // Grade Command Creator

--- a/src/main/java/seedu/duke/parser/InitCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/InitCommandMetadata.java
@@ -7,11 +7,10 @@ import java.util.Map;
 
 public class InitCommandMetadata extends CommandMetadata {
     private static final String INIT_KEYWORD = "init";
-    private static final String INIT_PATTERN_REGEX = "init\\s+n/(?<name>[A-Za-z0-9 ]+)";
     private static final String[] INIT_ARGUMENTS = {"name"};
 
     public InitCommandMetadata() {
-        super(INIT_KEYWORD, INIT_PATTERN_REGEX, INIT_ARGUMENTS);
+        super(INIT_KEYWORD, INIT_ARGUMENTS);
     }
 
     // Init Command Creator

--- a/src/main/java/seedu/duke/parser/InitCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/InitCommandMetadata.java
@@ -1,0 +1,24 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+import seedu.duke.command.InitCommand;
+
+import java.util.Map;
+
+public class InitCommandMetadata extends CommandMetadata {
+    private static final String INIT_KEYWORD = "init";
+    private static final String INIT_PATTERN_REGEX = "init\\s+n/(?<name>[A-Za-z0-9 ]+)";
+    private static final String[] INIT_ARGUMENTS = {"name"};
+
+    public InitCommandMetadata() {
+        super(INIT_KEYWORD, INIT_PATTERN_REGEX, INIT_ARGUMENTS);
+    }
+
+    // Init Command Creator
+    @Override
+    protected Command createCommandInstance(Map<String, String> args) {
+        String name = args.getOrDefault("name", "NAME_ERROR");
+
+        return new InitCommand(name);
+    }
+}

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -1,149 +1,50 @@
 package seedu.duke.parser;
 
-import seedu.duke.command.AddCommand;
-import seedu.duke.command.ByeCommand;
+import seedu.duke.exceptions.ParserException;
 import seedu.duke.command.Command;
-import seedu.duke.command.GradeCommand;
 import seedu.duke.command.InvalidCommand;
-import seedu.duke.command.InitCommand;
-import seedu.duke.command.RemoveCommand;
-import seedu.duke.command.ViewCommand;
-import seedu.duke.command.ViewGpaCommand;
-import seedu.duke.command.ViewGraduateCommand;
 
-import java.util.function.Function;
 import java.util.Map;
 import java.util.ArrayList;
-import java.util.logging.Level;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import seedu.duke.FAP;
-import seedu.duke.exceptions.ModuleNotFoundException;
-import seedu.duke.json.JsonManager;
-
-import static seedu.duke.FAP.LOGGER;
 
 public class Parser {
 
-    static JsonManager jsonManager = FAP.jsonManager;
-    // String Pattern inputs
-    private static final Pattern INIT_PATTERN =
-            Pattern.compile("init\\s+n/(?<name>[A-Za-z0-9 ]+)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern GPA_PATTERN =
-            Pattern.compile("gpa", Pattern.CASE_INSENSITIVE);
-    private static final Pattern VIEW_PATTERN =
-            Pattern.compile("view", Pattern.CASE_INSENSITIVE);
-    private static final Pattern GRADUATE_PATTERN =
-            Pattern.compile("graduate", Pattern.CASE_INSENSITIVE);
-    private static final Pattern REMOVE_MODULE_PATTERN =
-            Pattern.compile("remove\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern ADD_MODULE_PATTERN =
-            Pattern.compile("add\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)" +
-                    "\\s+w/(?<semester>[1-8])", Pattern.CASE_INSENSITIVE);
-    private static final Pattern GRADE_PATTERN =
-            Pattern.compile("grade\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)" +
-                    "\\s+g/(?<grade>[ab][+-]?|[cd][+]?|f|cs|cu)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern BYE_PATTERN =
-            Pattern.compile("bye", Pattern.CASE_INSENSITIVE);
-
-    // Argument Group captures
-    private static final String[] INIT_ARGUMENTS = {"name"};
-    private static final String[] GPA_ARGUMENTS = {};
-    private static final String[] VIEW_ARGUMENTS = {};
-    private static final String[] GRADUATE_ARGUMENTS = {};
-    private static final String[] REMOVE_MODULE_ARGUMENTS = {"courseCode"};
-    private static final String[] ADD_MODULE_ARGUMENTS = {"courseCode", "semester"};
-    private static final String[] GRADE_ARGUMENTS = {"courseCode", "grade"};
-    private static final String[] BYE_ARGUMENTS = {};
-
-    // Command constructor function
-    private static final Function<Map<String, String>, Command> INIT_CONSTRUCTOR = Parser::initCommand;
-    private static final Function<Map<String, String>, Command> GPA_CONSTRUCTOR = Parser::gpaCommand;
-    private static final Function<Map<String, String>, Command> VIEW_CONSTRUCTOR = Parser::viewCommand;
-    private static final Function<Map<String, String>, Command> GRADUATE_CONSTRUCTOR = Parser::graduateCommand;
-    private static final Function<Map<String, String>, Command> REMOVE_MODULE_CONSTRUCTOR = Parser::removeCommand;
-    private static final Function<Map<String, String>, Command> ADD_MODULE_CONSTRUCTOR = Parser::addCommand;
-    private static final Function<Map<String, String>, Command> GRADE_CONSTRUCTOR = Parser::gradeCommand;
-    private static final Function<Map<String, String>, Command> BYE_CONSTRUCTOR = Parser::byeCommand;
-
-    // Initialise ArrayList that puts all the commandMetadata together
-    private static final ArrayList<CommandMetadata> metadataList = initMetadataList();
-
-    private static ArrayList<CommandMetadata> initMetadataList() {
-        ArrayList<CommandMetadata> list = new ArrayList<>();
-
-        list.add(new CommandMetadata(INIT_PATTERN, INIT_ARGUMENTS, INIT_CONSTRUCTOR));
-        list.add(new CommandMetadata(GPA_PATTERN, GPA_ARGUMENTS, GPA_CONSTRUCTOR));
-        list.add(new CommandMetadata(VIEW_PATTERN, VIEW_ARGUMENTS, VIEW_CONSTRUCTOR));
-        list.add(new CommandMetadata(GRADUATE_PATTERN, GRADUATE_ARGUMENTS, GRADUATE_CONSTRUCTOR));
-        list.add(new CommandMetadata(REMOVE_MODULE_PATTERN, REMOVE_MODULE_ARGUMENTS, REMOVE_MODULE_CONSTRUCTOR));
-        list.add(new CommandMetadata(ADD_MODULE_PATTERN, ADD_MODULE_ARGUMENTS, ADD_MODULE_CONSTRUCTOR));
-        list.add(new CommandMetadata(GRADE_PATTERN, GRADE_ARGUMENTS, GRADE_CONSTRUCTOR));
-        list.add(new CommandMetadata(BYE_PATTERN, BYE_ARGUMENTS, BYE_CONSTRUCTOR));
-
-        return list;
+    private static ArrayList<CommandMetadata> metadataList = new ArrayList<>();
+    static {
+        metadataList.add(new InitCommandMetadata());
+        metadataList.add(new GpaCommandMetadata());
+        metadataList.add(new ViewCommandMetadata());
+        metadataList.add(new ViewGraduateCommandMetadata());
+        metadataList.add(new AddCommandMetadata());
+        metadataList.add(new RemoveCommandMetadata());
+        metadataList.add(new GradeCommandMetadata());
+        metadataList.add(new ByeCommandMetadata());
     }
 
     public static Command getCommand(String userInput) {
+        if (userInput == null || userInput.trim().isEmpty()) {
+            return new InvalidCommand();
+        }
+
+        userInput = userInput.trim();
+
         for (CommandMetadata commandMetadata : metadataList) {
-            Pattern commandPattern = commandMetadata.getPattern();
-            Matcher matcher = commandPattern.matcher(userInput);
-
-            if (matcher.matches()) {
-                Map<String, String> commandArguments = commandMetadata.getCommandArguments(matcher);
-                Function<Map<String, String>, Command> commandClassConstructor = commandMetadata.getConstructor();
-
-                Command commandInstance = commandClassConstructor.apply(commandArguments);
-                return commandInstance;
+            if (!commandMetadata.matchesKeyword(userInput)) {
+                continue; // Skip metadata if keyword doesn't match
+            }
+            try {
+                Matcher matcher = commandMetadata.getPattern().matcher(userInput);
+                if (matcher.matches()) {
+                    Map<String, String> commandArguments = commandMetadata.getCommandArguments(matcher);
+                    Command commandInstance = commandMetadata.createCommandInstance(commandArguments);
+                    return commandInstance;
+                }
+                commandMetadata.validateUserInput(userInput);
+            } catch (ParserException e) {
+                return new InvalidCommand(e.getMessage());
             }
         }
         return new InvalidCommand();
-    }
-
-    // Class Constructor functions
-    private static Command initCommand(Map<String, String> args) {
-        String name = args.getOrDefault("name", "NAME_ERROR");
-        return new InitCommand(name);
-    }
-
-    private static Command gpaCommand(Map<String, String> args) {
-        return new ViewGpaCommand();
-    }
-
-    private static Command viewCommand(Map<String, String> args) {
-        return new ViewCommand();
-    }
-
-    private static ViewGraduateCommand graduateCommand(Map<String, String> args) {
-        return new ViewGraduateCommand();
-    }
-
-    private static Command removeCommand(Map<String, String> args) {
-        return new RemoveCommand(args);
-    }
-
-    private static Command addCommand(Map<String, String> args) {
-        try {
-            String moduleCode = args.getOrDefault("courseCode", "COURSECODE_ERROR");
-            String semester = args.getOrDefault("semester", "SEMESTER_ERROR");
-            int semesterInt = Integer.parseInt(semester);
-
-            return new AddCommand(moduleCode, semesterInt);
-        } catch (ModuleNotFoundException e) {
-            LOGGER.log(Level.SEVERE, "An error occurred: " + e.getMessage());
-            System.out.println("An error occurred: " + e.getMessage());
-        }
-        return new InvalidCommand();
-    }
-
-    private static Command gradeCommand(Map<String, String> args) {
-        String moduleCode = args.getOrDefault("courseCode", "COURSECODE_ERROR");
-        String grade = args.getOrDefault("grade", "GRADE_ERROR");
-        return new GradeCommand(moduleCode, grade);
-    }
-
-    private static Command byeCommand(Map<String, String> args) {
-        return new ByeCommand();
     }
 }

--- a/src/main/java/seedu/duke/parser/RemoveCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/RemoveCommandMetadata.java
@@ -7,11 +7,10 @@ import java.util.Map;
 
 public class RemoveCommandMetadata extends CommandMetadata {
     private static final String REMOVE_KEYWORD = "remove";
-    private static final String REMOVE_PATTERN_REGEX = "remove\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)";
     private static final String[] REMOVE_ARGUMENTS = {"courseCode"};
 
     public RemoveCommandMetadata() {
-        super(REMOVE_KEYWORD, REMOVE_PATTERN_REGEX, REMOVE_ARGUMENTS);
+        super(REMOVE_KEYWORD, REMOVE_ARGUMENTS);
     }
 
     // Remove Command Creator

--- a/src/main/java/seedu/duke/parser/RemoveCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/RemoveCommandMetadata.java
@@ -1,0 +1,22 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+import seedu.duke.command.RemoveCommand;
+
+import java.util.Map;
+
+public class RemoveCommandMetadata extends CommandMetadata {
+    private static final String REMOVE_KEYWORD = "remove";
+    private static final String REMOVE_PATTERN_REGEX = "remove\\s+c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)";
+    private static final String[] REMOVE_ARGUMENTS = {"courseCode"};
+
+    public RemoveCommandMetadata() {
+        super(REMOVE_KEYWORD, REMOVE_PATTERN_REGEX, REMOVE_ARGUMENTS);
+    }
+
+    // Remove Command Creator
+    @Override
+    protected Command createCommandInstance(Map<String, String> args) {
+        return new RemoveCommand(args);
+    }
+}

--- a/src/main/java/seedu/duke/parser/ViewCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/ViewCommandMetadata.java
@@ -7,11 +7,10 @@ import java.util.Map;
 
 public class ViewCommandMetadata extends CommandMetadata {
     private static final String VIEW_KEYWORD = "view";
-    private static final String VIEW_PATTERN_REGEX = "view";
     private static final String[] VIEW_ARGUMENTS = {};
 
     public ViewCommandMetadata() {
-        super(VIEW_KEYWORD, VIEW_PATTERN_REGEX, VIEW_ARGUMENTS);
+        super(VIEW_KEYWORD, VIEW_ARGUMENTS);
     }
 
     // View Command Creator

--- a/src/main/java/seedu/duke/parser/ViewCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/ViewCommandMetadata.java
@@ -1,0 +1,22 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+import seedu.duke.command.ViewCommand;
+
+import java.util.Map;
+
+public class ViewCommandMetadata extends CommandMetadata {
+    private static final String VIEW_KEYWORD = "view";
+    private static final String VIEW_PATTERN_REGEX = "view";
+    private static final String[] VIEW_ARGUMENTS = {};
+
+    public ViewCommandMetadata() {
+        super(VIEW_KEYWORD, VIEW_PATTERN_REGEX, VIEW_ARGUMENTS);
+    }
+
+    // View Command Creator
+    @Override
+    protected Command createCommandInstance(Map<String, String> args) {
+        return new ViewCommand();
+    }
+}

--- a/src/main/java/seedu/duke/parser/ViewGraduateCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/ViewGraduateCommandMetadata.java
@@ -7,11 +7,10 @@ import java.util.Map;
 
 public class ViewGraduateCommandMetadata extends CommandMetadata {
     private static final String GRADUATE_KEYWORD = "graduate";
-    private static final String GRADUATE_PATTERN_REGEX = "graduate";
     private static final String[] GRADUATE_ARGUMENTS = {};
 
     public ViewGraduateCommandMetadata() {
-        super(GRADUATE_KEYWORD, GRADUATE_PATTERN_REGEX, GRADUATE_ARGUMENTS);
+        super(GRADUATE_KEYWORD, GRADUATE_ARGUMENTS);
     }
 
     // View Graduate Command Creator

--- a/src/main/java/seedu/duke/parser/ViewGraduateCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/ViewGraduateCommandMetadata.java
@@ -1,0 +1,22 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.Command;
+import seedu.duke.command.ViewGraduateCommand;
+
+import java.util.Map;
+
+public class ViewGraduateCommandMetadata extends CommandMetadata {
+    private static final String GRADUATE_KEYWORD = "graduate";
+    private static final String GRADUATE_PATTERN_REGEX = "graduate";
+    private static final String[] GRADUATE_ARGUMENTS = {};
+
+    public ViewGraduateCommandMetadata() {
+        super(GRADUATE_KEYWORD, GRADUATE_PATTERN_REGEX, GRADUATE_ARGUMENTS);
+    }
+
+    // View Graduate Command Creator
+    @Override
+    protected Command createCommandInstance(Map<String, String> args) {
+        return new ViewGraduateCommand();
+    }
+}

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -26,6 +26,10 @@ public class Ui {
         return currentLine;
     }
 
+    public static void printMessage(String str) {
+        System.out.println(str);
+    }
+
     private boolean shouldIgnore(String currentLine) {
         return currentLine.isBlank() || currentLine.trim().matches(COMMENT_LINE_FORMAT_REGEX);
     }

--- a/src/test/java/seedu/duke/FAPTest.java
+++ b/src/test/java/seedu/duke/FAPTest.java
@@ -75,7 +75,7 @@ public class FAPTest {
                 "What can I do for you?",
                 "__________________________________________________",
                 "__________________________________________________",
-                "INVALID COMMAND",
+                "init command: Error in name",
                 "__________________________________________________",
                 "An error occurred: No line found"
         ).replace(System.lineSeparator(), "\n");

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -65,8 +65,50 @@ public class ParserTest {
     }
 
     @Test
-    public void testInvalidCommand() {
-        String userInput = "invalid command";
+    public void testNullUserInput() {
+        String userInput = null;
+        Command command = Parser.getCommand(userInput);
+        assertTrue(command instanceof InvalidCommand);
+    }
+
+    @Test
+    public void testEmptyUserInput() {
+        String userInput = "";
+        Command command = Parser.getCommand(userInput);
+        assertTrue(command instanceof InvalidCommand);
+    }
+
+    @Test
+    public void testWhitespaceUserInput() {
+        String userInput = "    ";
+        Command command = Parser.getCommand(userInput);
+        assertTrue(command instanceof InvalidCommand);
+    }
+
+    @Test
+    public void testUnknownCommand() {
+        String userInput = "unknown";
+        Command command = Parser.getCommand(userInput);
+        assertTrue(command instanceof InvalidCommand);
+    }
+
+    @Test
+    public void testRemoveCommandWithoutCourseCode() {
+        String userInput = "remove";
+        Command command = Parser.getCommand(userInput);
+        assertTrue(command instanceof InvalidCommand);
+    }
+
+    @Test
+    public void testAddCommandWithoutCourseCodeAndSemester() {
+        String userInput = "add";
+        Command command = Parser.getCommand(userInput);
+        assertTrue(command instanceof InvalidCommand);
+    }
+
+    @Test
+    public void testGradeCommandWithoutCourseCodeAndGrade() {
+        String userInput = "grade";
         Command command = Parser.getCommand(userInput);
         assertTrue(command instanceof InvalidCommand);
     }


### PR DESCRIPTION
## Overview
Extracted code from `Parser` to hold CommandMetadata for all user commands available as of current. 
- Add command 
- Bye command
- GPA command 
- Grade command 
- Init command 
- Remove command 
- View command
- View Graduate command

Subclasses inherits from superclass `CommandMetadata`

**Use of the classes now are as follows:**

  `Parser` Class:
  - Interprets user input to determine actions.
  - Uses CommandMetadata to match input with commands.
  - Returns appropriate command objects.
  - Handles general case invalid input by returning `InvalidCommand`.

  `CommandMetadata` Abstract Class:
  - Stores command-related metadata.
  - Validates user input and checks for some errors.
  - Enables creation of valid command type instances.