### PR TITLE
Remove pillar modules from graduate command

### DIFF
--- a/src/main/java/seedu/duke/enums/CEGModules.java
+++ b/src/main/java/seedu/duke/enums/CEGModules.java
@@ -1,9 +1,6 @@
 package seedu.duke.enums;
 
 public enum CEGModules {
-    GESS(4),
-    GEC(4),
-    GEN(4),
     ES2631(4),
     CS1010(4),
     GEA1000(4),

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -123,6 +123,7 @@ public class Ui {
             System.out.println(paddedModuleCode + paddedModuleMC);
         }
         System.out.println("+---------------------------+------------+");
+        System.out.println("Be sure to also complete your GESS, GEC, and GEN modules.");
     }
 
     public static void printHyphens() {


### PR DESCRIPTION
## Changes
- Calling `graduate` now shows the message "Be sure to also complete your GESS, GEC, and GEN modules." in addition to the original table.
- Removed GESS, GEC, and GEN from `CEGModules.java` enum.