### PR TITLE
Support Equivalent Modules

### DIFF
--- a/src/main/java/seedu/duke/enums/CEGModules.java
+++ b/src/main/java/seedu/duke/enums/CEGModules.java
@@ -1,42 +1,53 @@
 package seedu.duke.enums;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public enum CEGModules {
-    ES2631(4),
-    CS1010(4),
-    GEA1000(4),
-    DTK1234(4),
-    EG1311(4),
-    IE2141(4),
-    EE2211(4),
-    EG2501(4),
-    CDE2000(4),
-    PF1101(4),
-    CG4002(8),
-    MA1511(2),
-    MA1512(2),
-    MA1508E(4),
-    EG2401A(2),
-    EG3611A(10),
-    CG1111A(4),
-    CG2111A(4),
-    CS1231(4),
-    CG2023(4),
-    CG2027(2),
-    CG2028(2),
-    CG2271(4),
-    CS2040C(4),
-    CS2113(4),
-    EE2026(4),
-    EE4204(4);
+    ES2631(4, null),
+    CS1010(4, null),
+    GEA1000(4, null),
+    DTK1234(4, null),
+    EG1311(4, null),
+    IE2141(4, null),
+    EE2211(4, null),
+    CDE2501(4, null),
+    CDE2000(4, null),
+    PF1101(4, null),
+    CG4002(8, null),
+    MA1511(2, null),
+    MA1512(2, null),
+    MA1508E(4, null),
+    EG2401A(2, null),
+    EG3611A(10, new ArrayList<>(List.of("CP3880"))),
+    CP3880(12, new ArrayList<>(List.of("EG3611A"))),
+    CG1111A(4, null),
+    CG2111A(4, null),
+    CS1231(4, null),
+    CG2023(4, null),
+    CG2027(2, null),
+    CG2028(2, null),
+    CG2271(4, null),
+    CS2040C(4, null),
+    CS2113(4, null),
+    EE2026(4, null),
+    EE4204(4, null);
 
     private final int moduleMC;
+    private final ArrayList<String> equivalent;
 
-    CEGModules(int moduleMC) {
+    CEGModules(int moduleMC, ArrayList<String> equivalent) {
         this.moduleMC = moduleMC;
+        this.equivalent = equivalent;
     }
 
     public int getModuleMC() {
         return moduleMC;
+    }
+
+    public ArrayList<String> getEquivalent() {
+        return equivalent;
     }
 
     public static CEGModules mapStringToEnum(String moduleCode) {

--- a/src/main/java/seedu/duke/enums/CEGModules.java
+++ b/src/main/java/seedu/duke/enums/CEGModules.java
@@ -1,7 +1,6 @@
 package seedu.duke.enums;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public enum CEGModules {

--- a/src/main/java/seedu/duke/modules/ModuleList.java
+++ b/src/main/java/seedu/duke/modules/ModuleList.java
@@ -6,7 +6,6 @@ import seedu.duke.exceptions.ModuleException;
 import seedu.duke.exceptions.ModuleNotFoundException;
 import seedu.duke.user.User;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/seedu/duke/modules/ModuleList.java
+++ b/src/main/java/seedu/duke/modules/ModuleList.java
@@ -6,6 +6,7 @@ import seedu.duke.exceptions.ModuleException;
 import seedu.duke.exceptions.ModuleNotFoundException;
 import seedu.duke.user.User;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -120,7 +121,11 @@ public class ModuleList {
 
     public boolean containsModule(String moduleCode) {
         for (Module takenModule : moduleList) {
-            if (moduleCode.equals(takenModule.getModuleCode())) {
+            ArrayList<String> equivalentList = CEGModules
+                    .mapStringToEnum(takenModule.getModuleCode())
+                    .getEquivalent();
+            boolean hasEquivalent = equivalentList != null && equivalentList.contains(moduleCode);
+            if (hasEquivalent || moduleCode.equals(takenModule.getModuleCode())) {
                 return true;
             }
         }

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -112,6 +112,7 @@ public class Ui {
     public static void printModulesToComplete(ArrayList<String> modulesToComplete) {
         int courseCodeTableWidth = 25;
         int mcTableWidth = 10;
+        int borderWidth = 5;
 
         System.out.println("+---------------------------+------------+");
         System.out.println("| Course Code               | MCs        |");
@@ -123,7 +124,20 @@ public class Ui {
             System.out.println(paddedModuleCode + paddedModuleMC);
         }
         System.out.println("+---------------------------+------------+");
-        System.out.println("Be sure to also complete your GESS, GEC, and GEN modules.");
+        printWrappedText("Be sure to also complete 40MCs of Unrestricted Electives, GESS, GEC, and GEN modules.",
+                courseCodeTableWidth + mcTableWidth + borderWidth);
+    }
+
+    public static void printWrappedText(String text, int lineWidth) {
+        int length = text.length();
+        int start = 0;
+        int end = Math.min(lineWidth, length);
+
+        while (start < length) {
+            System.out.println(text.substring(start, end));
+            start = end;
+            end = Math.min(start + lineWidth, length);
+        }
     }
 
     public static void printHyphens() {


### PR DESCRIPTION
## Overview
- `CEGModules.java` now supports equivalent modules (i.e. EG3611A and CP3880)
- Clearing one of the equivalent modules will remove both from the modules needed to graduate list.
## Changes
- Added footnote reminding users to complete 40 UE MCs.
- Changed `EG2501` to `CDE2501`.
- Added `printWrappedText` to print wrapped texts.
- `equivalent` field in CEGModules.
