### PR TITLE
View Specifc Modules

### DIFF
--- a/src/main/java/seedu/duke/command/ViewCommand.java
+++ b/src/main/java/seedu/duke/command/ViewCommand.java
@@ -3,6 +3,7 @@ package seedu.duke.command;
 import java.util.ArrayList;
 import java.util.Map;
 
+import static seedu.duke.FAP.jsonManager;
 import static seedu.duke.FAP.user;
 
 import seedu.duke.modules.Module;
@@ -16,11 +17,28 @@ public class ViewCommand extends Command {
     private int takenMCs = moduleList.calculateTakenMCs();
     private int totalMCs = moduleList.calculateTotalMCs();
     private Map<Integer, ArrayList<Module>> modulesBySemMap = moduleList.groupModulesBySemester();
+    private final Map<String, String> args;
+
+    public ViewCommand(Map<String, String> args) {
+        this.args = args;
+    }
 
     @Override
     public void execute(String userInput) {
-        Ui.printScheduleHeader(name);
-        Ui.printModulePlan(modulesBySemMap);
-        Ui.printScheduleDetails(currSem, gradSem, takenMCs, totalMCs);
+        if (args.containsKey("courseCode")) {
+            if (jsonManager.moduleExist(args.get("courseCode"))) {
+                Map<String, String> moduleInfo = jsonManager.queryModuleInfo(args.get("courseCode"));
+                String moduleTitle = moduleInfo.get("moduleTitle");
+                String moduleMC = moduleInfo.get("moduleMC");
+                String moduleDescription = moduleInfo.get("moduleDescription");
+                Ui.printViewModule(moduleTitle, moduleMC, moduleDescription);
+            } else {
+                System.out.println("No such module found in NUS AY23-24!");
+            }
+        } else {
+            Ui.printScheduleHeader(name);
+            Ui.printModulePlan(modulesBySemMap);
+            Ui.printScheduleDetails(currSem, gradSem, takenMCs, totalMCs);
+        }
     }
 }

--- a/src/main/java/seedu/duke/json/JsonManager.java
+++ b/src/main/java/seedu/duke/json/JsonManager.java
@@ -3,10 +3,13 @@ package seedu.duke.json;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.JsonObject;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class JsonManager {
 
@@ -32,10 +35,11 @@ public class JsonManager {
         this.gson = new Gson();
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
-            Type type = new TypeToken<List<JsonObject>>(){}.getType();
+            Type type = new TypeToken<List<JsonObject>>() {
+            }.getType();
             jsonArray = gson.fromJson(reader, type);
             this.reader = reader;
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -67,6 +71,19 @@ public class JsonManager {
                 this.moduleTitle = obj.get("title").getAsString();
             }
         }
+    }
+
+    public Map<String, String> queryModuleInfo(String moduleCode) {
+        Map<String, String> moduleInfo = new HashMap<>();
+        for (JsonObject obj : jsonArray) {
+            String name = obj.get("moduleCode").getAsString();
+            if (name.equals(moduleCode)) {
+                moduleInfo.put("moduleTitle", obj.get("title").getAsString());
+                moduleInfo.put("moduleMC", obj.get("moduleCredit").getAsString());
+                moduleInfo.put("moduleDescription", obj.get("description").getAsString());
+            }
+        }
+        return moduleInfo;
     }
 
     public String getModuleDescription() {

--- a/src/main/java/seedu/duke/parser/CommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/CommandMetadata.java
@@ -16,6 +16,7 @@ public abstract class CommandMetadata {
 
     private static Logger logger = Logger.getLogger("CommandMetadata");
     private static Map<String, String> argRegexMap = new HashMap<>();
+
     static {
         logger.setLevel(Level.OFF);
 
@@ -31,6 +32,7 @@ public abstract class CommandMetadata {
 
     private String keyword;
     private String[] groupArguments;
+    private String[] groupArgumentFlags;
     private String regex;
     private int regexLength;
     private Pattern pattern;
@@ -43,6 +45,20 @@ public abstract class CommandMetadata {
         this.groupArguments = groupArguments;
 
         this.regex = generateRegex(keyword, groupArguments);
+        this.regexLength = groupArguments.length + 1; // Keyword + number of Arguments
+        this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+    }
+
+    protected CommandMetadata(String keyword, String[] groupArguments, String[] groupArgumentFlags)
+            throws IllegalArgumentException {
+        if (keyword == null || groupArguments == null) {
+            throw new IllegalArgumentException("Keyword, regex, and group arguments cannot be null");
+        }
+        this.keyword = keyword;
+        this.groupArguments = groupArguments;
+        this.groupArgumentFlags = groupArgumentFlags;
+
+        this.regex = generateRegex(keyword, groupArguments, groupArgumentFlags);
         this.regexLength = groupArguments.length + 1; // Keyword + number of Arguments
         this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
     }
@@ -83,6 +99,23 @@ public abstract class CommandMetadata {
         return regexPattern.toString();
     }
 
+    private static String generateRegex(String keyword, String[] groupArguments, String[] groupArgumentFlags) {
+        if (keyword == null || groupArguments == null || groupArgumentFlags == null) {
+            throw new IllegalArgumentException("Keyword, groupArguments and flags must not be null");
+        }
+        assert groupArgumentFlags.length == groupArguments.length : "Arguments and Flags must be of the same size!";
+
+        StringBuilder regexPattern = new StringBuilder(keyword);
+        for (int i = 0; i < groupArguments.length; i++) {
+            if (groupArgumentFlags[i].equals("optional")) {
+                appendOptionalRegex(regexPattern, groupArguments[i]);
+            } else {
+                appendRegex(regexPattern, groupArguments[i]);
+            }
+        }
+        return regexPattern.toString();
+    }
+
     // Helper function for generateRegex
     private static void appendRegex(StringBuilder regexPattern, String groupArgName) {
         String argRegex = argRegexMap.get(groupArgName);
@@ -90,6 +123,15 @@ public abstract class CommandMetadata {
             throw new IllegalArgumentException("No regex pattern found for argument: " + groupArgName);
         }
         regexPattern.append("\\s+").append(argRegex);
+    }
+
+    private static void appendOptionalRegex(StringBuilder regexPattern, String groupArgName) {
+        String argRegex = argRegexMap.get(groupArgName);
+        if (argRegex == null) {
+            throw new IllegalArgumentException("No regex pattern found for argument: " + groupArgName);
+        }
+        String optionalGroup = "(\\s+" + argRegex + ")?";
+        regexPattern.append(optionalGroup);
     }
 
     protected boolean matchesKeyword(String userInput) {
@@ -182,7 +224,7 @@ public abstract class CommandMetadata {
             throw new IllegalArgumentException("Regex length should be keyword + number of arguments");
         }
         for (int i = 0; i < groupArguments.length; i++) {
-            validateUserArguments(userInputParts[i+1], groupArguments[i]);
+            validateUserArguments(userInputParts[i + 1], groupArguments[i]);
         }
     }
 

--- a/src/main/java/seedu/duke/parser/CommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/CommandMetadata.java
@@ -38,15 +38,7 @@ public abstract class CommandMetadata {
     private Pattern pattern;
 
     protected CommandMetadata(String keyword, String[] groupArguments) throws IllegalArgumentException {
-        if (keyword == null || groupArguments == null) {
-            throw new IllegalArgumentException("Keyword, regex, and group arguments cannot be null");
-        }
-        this.keyword = keyword;
-        this.groupArguments = groupArguments;
-
-        this.regex = generateRegex(keyword, groupArguments);
-        this.regexLength = groupArguments.length + 1; // Keyword + number of Arguments
-        this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        this(keyword, groupArguments, null);
     }
 
     protected CommandMetadata(String keyword, String[] groupArguments, String[] groupArgumentFlags)
@@ -56,6 +48,15 @@ public abstract class CommandMetadata {
         }
         this.keyword = keyword;
         this.groupArguments = groupArguments;
+
+        if (groupArgumentFlags == null) {
+            groupArgumentFlags = new String[groupArguments.length];
+            Arrays.fill(groupArgumentFlags, "mandatory"); // default flag
+        }
+        if (groupArgumentFlags.length != groupArguments.length) {
+            throw new IllegalArgumentException("Group Argument and Group Argument Flags does not have the same size!");
+        }
+
         this.groupArgumentFlags = groupArgumentFlags;
 
         this.regex = generateRegex(keyword, groupArguments, groupArgumentFlags);
@@ -85,18 +86,6 @@ public abstract class CommandMetadata {
 
     protected Map<String, String> getArgRegexMap() {
         return argRegexMap;
-    }
-
-    private static String generateRegex(String keyword, String[] groupArguments) {
-        if (keyword == null || groupArguments == null) {
-            throw new IllegalArgumentException("Keyword and groupArguments must not be null");
-        }
-
-        StringBuilder regexPattern = new StringBuilder(keyword);
-        for (String groupArgName : groupArguments) {
-            appendRegex(regexPattern, groupArgName);
-        }
-        return regexPattern.toString();
     }
 
     private static String generateRegex(String keyword, String[] groupArguments, String[] groupArgumentFlags) {

--- a/src/main/java/seedu/duke/parser/ViewCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/ViewCommandMetadata.java
@@ -17,6 +17,6 @@ public class ViewCommandMetadata extends CommandMetadata {
     // View Command Creator
     @Override
     protected Command createCommandInstance(Map<String, String> args) {
-        return new ViewCommand();
+        return new ViewCommand(args);
     }
 }

--- a/src/main/java/seedu/duke/parser/ViewCommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/ViewCommandMetadata.java
@@ -7,10 +7,11 @@ import java.util.Map;
 
 public class ViewCommandMetadata extends CommandMetadata {
     private static final String VIEW_KEYWORD = "view";
-    private static final String[] VIEW_ARGUMENTS = {};
+    private static final String[] VIEW_ARGUMENTS = {"courseCode"};
+    private static final String[] VIEW_ARG_FLAGS = {"optional"};
 
     public ViewCommandMetadata() {
-        super(VIEW_KEYWORD, VIEW_ARGUMENTS);
+        super(VIEW_KEYWORD, VIEW_ARGUMENTS, VIEW_ARG_FLAGS);
     }
 
     // View Command Creator

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -11,16 +11,16 @@ public class Ui {
     private static final String COMMENT_LINE_FORMAT_REGEX = "#.*";
     private static final String COMMANDS_HELP_MESSAGE =
             "Available Commands:\n" +
-            "NOTE: \"<WORD>\" represents a user-typed argument that is required for the command\n" +
-            "1. init n/<NAME> curr/<CURR_SEM> grad/<GRAD_SEM> - Set name, current & expected grad semester\n" +
-            "2. add c/<COURSE_CODE> w/<WHEN> - Add a module to your schedule\n" +
-            "3. remove c/<COURSE_CODE> - Remove a module from your schedule\n" +
-            "4. grade c/<COURSE_CODE> g/<GRADE> - Add or change a module grade\n" +
-            "5. gpa - View your GPA\n" +
-            "6. desiredgpa <GPA> - Calculates grades needed to achieve a desired GPA\n" +
-            "7. view - View modules on your schedule\n" +
-            "8. graduate - View remaining core modules and MCs left to graduate\n" +
-            "9. help - View command syntax and list of commands available for FAP";
+                    "NOTE: \"<WORD>\" represents a user-typed argument that is required for the command\n" +
+                    "1. init n/<NAME> curr/<CURR_SEM> grad/<GRAD_SEM> - Set name, current & expected grad semester\n" +
+                    "2. add c/<COURSE_CODE> w/<WHEN> - Add a module to your schedule\n" +
+                    "3. remove c/<COURSE_CODE> - Remove a module from your schedule\n" +
+                    "4. grade c/<COURSE_CODE> g/<GRADE> - Add or change a module grade\n" +
+                    "5. gpa - View your GPA\n" +
+                    "6. desiredgpa <GPA> - Calculates grades needed to achieve a desired GPA\n" +
+                    "7. view - View modules on your schedule\n" +
+                    "8. graduate - View remaining core modules and MCs left to graduate\n" +
+                    "9. help - View command syntax and list of commands available for FAP";
     private final Scanner in;
 
     public Ui() {
@@ -164,18 +164,59 @@ public class Ui {
         }
         System.out.println("+---------------------------+------------+");
         printWrappedText("Be sure to also complete 40MCs of Unrestricted Electives, GESS, GEC, and GEN modules.",
-                courseCodeTableWidth + mcTableWidth + borderWidth);
+                courseCodeTableWidth + mcTableWidth + borderWidth, 0);
     }
 
-    public static void printWrappedText(String text, int lineWidth) {
-        int length = text.length();
-        int start = 0;
-        int end = Math.min(lineWidth, length);
+    public static void printViewModule(String courseTitle, String courseMC, String courseDescription) {
+        int minimumTableWidth = 50;
+        int spaceBetween = 10;
+        int titleLength = courseTitle.length() + " Title: ".length();
+        int creditsLength = courseMC.length() + " Credits: ".length();
+        int padding = 2;
+        int border = 2;
 
-        while (start < length) {
-            System.out.println(text.substring(start, end));
+        int contentWidth = titleLength + spaceBetween + creditsLength + padding;
+        int separatorWidth = Math.max(minimumTableWidth, contentWidth);
+        int calculatedSpaceBetween = Math.max(minimumTableWidth - contentWidth, 0);
+
+        System.out.println("=".repeat(separatorWidth));
+        System.out.println(String.format("| Title: %s%s          Credits: %s |",
+                courseTitle,
+                " ".repeat(calculatedSpaceBetween),
+                courseMC));
+        System.out.println("=".repeat(separatorWidth));
+        printWrappedText("Description: " + courseDescription,
+                separatorWidth - padding - border,
+                separatorWidth - padding - border);
+        System.out.println("=".repeat(separatorWidth));
+    }
+
+    public static void printWrappedText(String text, int width, int tableWidth) {
+        int start = 0;
+        int end = 0;
+
+        while (end < text.length()) {
+            end = start + width;
+            if (end >= text.length()) {
+                end = text.length();
+            } else {
+                while (end > start && !Character.isWhitespace(text.charAt(end))) {
+                    end--;
+                }
+                if (end == start) {
+                    end = start + width;
+                }
+            }
+            if (tableWidth > 0) { // print with border
+                System.out.println(String.format("| %-" + tableWidth + "s |", text.substring(start, end)));
+            } else {
+                System.out.println(text.substring(start, end));
+            }
+
             start = end;
-            end = Math.min(start + lineWidth, length);
+            while (start < text.length() && Character.isWhitespace(text.charAt(start))) {
+                start++;
+            }
         }
     }
 

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -19,8 +19,9 @@ public class Ui {
                     "5. gpa - View your GPA\n" +
                     "6. desiredgpa <GPA> - Calculates grades needed to achieve a desired GPA\n" +
                     "7. view - View modules on your schedule\n" +
-                    "8. graduate - View remaining core modules and MCs left to graduate\n" +
-                    "9. help - View command syntax and list of commands available for FAP";
+                    "8. view c/<COURSE_CODE> - View selected module information\n" +
+                    "9. graduate - View remaining core modules and MCs left to graduate\n" +
+                    "10. help - View command syntax and list of commands available for FAP";
     private final Scanner in;
 
     public Ui() {

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -11,8 +11,9 @@ NOTE: "<WORD>" represents a user-typed argument that is required for the command
 5. gpa - View your GPA
 6. desiredgpa <GPA> - Calculates grades needed to achieve a desired GPA
 7. view - View modules on your schedule
-8. graduate - View remaining core modules and MCs left to graduate
-9. help - View command syntax and list of commands available for FAP
+8. view c/<COURSE_CODE> - View selected module information
+9. graduate - View remaining core modules and MCs left to graduate
+10. help - View command syntax and list of commands available for FAP
 __________________________________________________
 __________________________________________________
 Greetings James Gosling! Your details are updated:


### PR DESCRIPTION
## Overview
- `view` command can now be either `view` or `view c/[COURSE_CODE]`
- `view c/[COURSE_CODE]` will now show description of course

## Changes
- Added String array `VIEW_ARG_FLAGS` in `ViewCommandMetadata.java` to store optional arguments.
- Added `appendOptionalRegex`, `generateRegex` (with `groupArgumentFlags`), `CommandMetadata` constructor (with `groupArgumentFlags`) to support optional argument `c/[COURSE_CODE]` in ViewCommandMetadata. 
- Added `queryModuleInfo` in `JsonManager.java` to return module info as a `Map<String, String>` instead of saving to current instance.
- Added `printViewModule` in `Ui.java`

## Additional Note
- Separate methods in `CommandMetadata.java` were made to avoid colliding and breaking previously written code, can merge the newly written code (i.e. constructor with 3 arguments, `appendOptionalRegex`, etc.) into the previous code if it isn't buggy.

## Expected Output
![image](https://github.com/AY2324S2-CS2113-W14-3/tp/assets/117452546/c263ed39-6b49-428f-9d1b-281312e9a9fa)

