### PR TITLE
Fix unable to use coursecode starting with 4 alphabets

### DIFF
--- a/src/main/java/seedu/duke/parser/CommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/CommandMetadata.java
@@ -22,7 +22,7 @@ public abstract class CommandMetadata {
         argRegexMap.put("name", "n/(?<name>[A-Za-z]+(?: [A-Za-z]+)*)");
         argRegexMap.put("currentSem", "curr/(?<currentSem>[1-8])");
         argRegexMap.put("graduationSem", "grad/(?<graduationSem>[1-8])");
-        argRegexMap.put("courseCode", "c/(?<courseCode>[A-Za-z]{2,3}\\d{4}[A-Za-z]?)");
+        argRegexMap.put("courseCode", "c/(?<courseCode>[A-Za-z]{2,4}\\d{4}[A-Za-z]?)");
         argRegexMap.put("semester", "w/(?<semester>[1-8])");
         argRegexMap.put("mc", "m/(?<mc>[1-9]|1[0-2])");
         argRegexMap.put("grade", "g/(?<grade>[ab][+-]?|[cd][+]?|f|cs)");

--- a/src/main/java/seedu/duke/parser/CommandMetadata.java
+++ b/src/main/java/seedu/duke/parser/CommandMetadata.java
@@ -22,7 +22,7 @@ public abstract class CommandMetadata {
         argRegexMap.put("name", "n/(?<name>[A-Za-z]+(?: [A-Za-z]+)*)");
         argRegexMap.put("currentSem", "curr/(?<currentSem>[1-8])");
         argRegexMap.put("graduationSem", "grad/(?<graduationSem>[1-8])");
-        argRegexMap.put("courseCode", "c/(?<courseCode>[A-Za-z]{2,4}\\d{4}[A-Za-z]?)");
+        argRegexMap.put("courseCode", "c/(?<courseCode>[a-zA-Z0-9]+)");
         argRegexMap.put("semester", "w/(?<semester>[1-8])");
         argRegexMap.put("mc", "m/(?<mc>[1-9]|1[0-2])");
         argRegexMap.put("grade", "g/(?<grade>[ab][+-]?|[cd][+]?|f|cs)");

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -104,7 +104,7 @@ public class Ui {
     private static void printSemesterTableHeader(String... semesters) {
         System.out.print("|");
         for (String semester : semesters) {
-            System.out.printf("%-11s|", semester);
+            System.out.printf("%-14s|", semester);
         }
         System.out.println();
     }
@@ -132,7 +132,7 @@ public class Ui {
                 String moduleCode = (module != null) ? module.getModuleCode() : "";
                 String moduleGrade = (module != null && module.getModuleGrade() != null) ? module.getModuleGrade() : "";
 
-                System.out.printf(" %-8s %-2s", moduleCode, moduleGrade);
+                System.out.printf(" %-11s %-2s", moduleCode, moduleGrade);
             }
             System.out.println(" ");
         }
@@ -179,8 +179,9 @@ public class Ui {
         }
     }
 
+    //@@author dextboy
     public static void printHyphens() {
-        System.out.println("__________________________________________________");
+        System.out.println("_____________________________________________________________");
     }
 
     public static void printExit() {

--- a/src/test/java/seedu/duke/FAPTest.java
+++ b/src/test/java/seedu/duke/FAPTest.java
@@ -54,6 +54,7 @@ public class FAPTest {
         return String.join(System.lineSeparator(), lines) + System.lineSeparator();
     }
 
+    //@@ author dextboy
     @Test
     public void testInit() {
         String simulatedUserInput = "init n/bob curr/4 grad/8" + System.lineSeparator() +
@@ -65,12 +66,12 @@ public class FAPTest {
         String output = testOut.toString().replace(System.lineSeparator(), "\n");
 
         String expectedOutput = buildExpectedOutput(
-                "__________________________________________________",
+                "_____________________________________________________________",
                 "Greetings bob! Your details are updated:",
                 "You are currently in Semester 4",
                 "You are expected to graduate in Semester 8",
-                "__________________________________________________",
-                "__________________________________________________",
+                "_____________________________________________________________",
+                "_____________________________________________________________",
                 "Bye. Enjoy your studies!"
         ).replace(System.lineSeparator(), "\n");
 
@@ -86,11 +87,11 @@ public class FAPTest {
         String output = testOut.toString().replace(System.lineSeparator(), "\n");
 
         String expectedOutput = buildExpectedOutput(
-                "__________________________________________________",
+                "_____________________________________________________________",
                 "Invalid init command: Invalid argument format/delimiters used",
                 "Type \"help\" to view the list & syntax of available commands",
-                "__________________________________________________",
-                "__________________________________________________",
+                "_____________________________________________________________",
+                "_____________________________________________________________",
                 "Bye. Enjoy your studies!"
         ).replace(System.lineSeparator(), "\n");
 

--- a/src/test/java/seedu/duke/ui/UiTest.java
+++ b/src/test/java/seedu/duke/ui/UiTest.java
@@ -28,10 +28,10 @@ public class UiTest {
     void printGreeting() {
         Ui.printGreeting();
         String expectedOutput = buildExpectedOutput(
-                "__________________________________________________",
+                "_____________________________________________________________",
                 "Hello! This is your CEG Future Academic Planner!",
                 "What would you like to do today?",
-                "__________________________________________________"
+                "_____________________________________________________________"
         );
         assertEquals(expectedOutput , outContent.toString());
     }
@@ -39,7 +39,7 @@ public class UiTest {
     @Test
     void printHyphens() {
         Ui.printHyphens();
-        assertEquals("__________________________________________________", outContent.toString().trim());
+        assertEquals("_____________________________________________________________", outContent.toString().trim());
     }
 
     @Test

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -1,7 +1,7 @@
-__________________________________________________
+_____________________________________________________________
 Hello! This is your CEG Future Academic Planner!
 What would you like to do today?
-__________________________________________________
+_____________________________________________________________
 Available Commands:
 NOTE: "<WORD>" represents a user-typed argument that is required for the command
 1. init n/<NAME> curr/<CURR_SEM> grad/<GRAD_SEM> - Set name, current & expected grad semester
@@ -14,11 +14,11 @@ NOTE: "<WORD>" represents a user-typed argument that is required for the command
 8. view c/<COURSE_CODE> - View selected module information
 9. graduate - View remaining core modules and MCs left to graduate
 10. help - View command syntax and list of commands available for FAP
-__________________________________________________
-__________________________________________________
+_____________________________________________________________
+_____________________________________________________________
 Greetings James Gosling! Your details are updated:
 You are currently in Semester 1
 You are expected to graduate in Semester 8
-__________________________________________________
-__________________________________________________
+_____________________________________________________________
+_____________________________________________________________
 Bye. Enjoy your studies!


### PR DESCRIPTION
As mentioned. Fixes failure to add modules like "GESS1025"

Edit: Extends to coursecodes such as "LC6009GRSII", View Command will also be changed to accomadate for that length